### PR TITLE
Clear the bounty when a brew is completed.

### DIFF
--- a/src/coffee.coffee
+++ b/src/coffee.coffee
@@ -281,6 +281,7 @@ module.exports = (robot) ->
       , dibsDuration * 1000
 
     brewing = {}
+    clearBounty
     robot.brain.save()
 
   freeSpots = ->


### PR DESCRIPTION
Looks like I forgot to clear the bounty when a brew was completed resulting in the bounty price never being able to go down.