### PR TITLE
Remove the @team notification on completed brews.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-coffee",
   "description": "A hubot script for announcing & claiming coffee",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "brent@kiratalent.com",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts, coffee",

--- a/src/coffee.coffee
+++ b/src/coffee.coffee
@@ -236,8 +236,6 @@ module.exports = (robot) ->
           "To end the brew use: `#{robot.alias}fresh pot`"
 
   endBrew = (msg) ->
-    teamNotify = brewing.dibs.length < dibsLimit
-
     expiry = new Date (new Date()).getTime() + dibsDuration * 1000
 
     claims = []
@@ -274,7 +272,7 @@ module.exports = (robot) ->
         claims.push "_Unclaimed!_"
 
     threadMsg = threadedMsg(msg)
-    threadMsg.send "#{if teamNotify then '@team: ' else ''}Fresh Pot!!! #{msg.random freshPots} " +
+    threadMsg.send "Fresh Pot!!! #{msg.random freshPots} " +
         ":coffee: Claims (valid until #{dateformat expiry, 'h:MM:ss tt'}):\n" +
         ("#{(parseInt index) + 1}. #{claim}" for index, claim of claims).join("\n")
 


### PR DESCRIPTION
The @ team notifications are causing two issues:

1. Coffee vultures are waiting for unclaimed spots without using the dibs systems
2. Too many notifications. For each brew there are at least 2 @ team notifications.